### PR TITLE
Fix test failure in 64bit environment.

### DIFF
--- a/src/crypt_fallback.c
+++ b/src/crypt_fallback.c
@@ -46,6 +46,9 @@ static char sccsid[] = "@(#)crypt.c	8.1 (Berkeley) 6/4/93";
 #define _PASSWORD_EFMT1 '_'
 #endif
 
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+
 /*
  * UNIX password, and DES, encryption.
  * By Tom Truscott, trt@rti.rti.org,
@@ -83,7 +86,7 @@ static char sccsid[] = "@(#)crypt.c	8.1 (Berkeley) 6/4/93";
  * define "LONG_IS_32_BITS" only if sizeof(long)==4.
  * This avoids use of bit fields (your compiler may be sloppy with them).
  */
-#if !defined(cray)
+#if !defined(cray) && LONG_MAX == INT32_MAX
 #define	LONG_IS_32_BITS
 #endif
 

--- a/src/string-crypt.c
+++ b/src/string-crypt.c
@@ -25,8 +25,6 @@ mrb_string_crypt(mrb_state* mrb, mrb_value self) {
 
 void
 mrb_mruby_string_crypt_gem_init(mrb_state* mrb) {
-  struct RClass *clazz;
-
   mrb_define_module_function(mrb, mrb->string_class, "crypt", mrb_string_crypt, MRB_ARGS_REQ(1));
 }
 


### PR DESCRIPTION
See log: https://103.128.221.202.static.iijgio.jp/jenkins/view/0-master-mrbgem/job/master-mruby-string-crypt/84/console
In 64bit environment `long` is 64bit but `crypt` function implementation doesn't know it.